### PR TITLE
Try offsetting by 0 to fix overlay

### DIFF
--- a/pointer.json
+++ b/pointer.json
@@ -6,7 +6,7 @@
 		"https://raw.githubusercontent.com/uis246/template/master/mask.png"
 	],
 	"name": "mlp",
-	"offX": 500,
+	"offX": 0,
 	"offY": 0,
 	"mux": false
 }


### PR DESCRIPTION
Overlay has been too far to the left since the last expansion. I suspect this should fix it but I haven't been able to test it.